### PR TITLE
use `debug_pdo` param when available

### DIFF
--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -134,6 +134,10 @@ class PropelExtension extends Extension
 
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
+        if ($container->hasParameter('debug_pdo')) {
+            return new Configuration($container->getParameter('debug_pdo'));
+        }
+
         return new Configuration($container->getParameter('kernel.debug'));
     }
 


### PR DESCRIPTION
When in dev and test environments, `kernel.debug` is `true`. this means that tests are slow, because an instance of `DebugPDO` is created and performs extra query logging, which is rarely needed during the CI test runs. This adds a switch to be able to explicitly specify if we want to use the debug config, without affecting current behaviour.